### PR TITLE
[STUDIO-1657] Resolve cannot export HTML with big Test Suite

### DIFF
--- a/Include/scripts/groovy/com/kms/katalon/core/reporting/basic/reporting/ReportWriterUtil.java
+++ b/Include/scripts/groovy/com/kms/katalon/core/reporting/basic/reporting/ReportWriterUtil.java
@@ -45,8 +45,16 @@ import com.kms.katalon.core.testdata.reader.CsvWriter;
 import com.kms.katalon.core.util.internal.DateUtil;
 
 public class ReportWriterUtil {
-
-    private static StringBuilder generateVars(List<String> strings, TestSuiteLogRecord suiteLogEntity,
+    
+    private static void appendReportConstantValues(List<String> constantValues, StringBuilder stringBuilder) {
+        for (String value : constantValues) {
+            stringBuilder.append(value);
+            stringBuilder.append(",");
+        }
+        stringBuilder.deleteCharAt(stringBuilder.length() - 1);
+    }
+    
+    private static String generateVars(List<String> strings, TestSuiteLogRecord suiteLogEntity,
             StringBuilder model) throws IOException {
         StringBuilder sb = new StringBuilder();
         List<String> lines = IOUtils
@@ -55,7 +63,7 @@ public class ReportWriterUtil {
             if (line.equals(ResourceLoader.HTML_TEMPLATE_SUITE_MODEL_TOKEN)) {
                 sb.append(model);
             } else if (line.equals(ResourceLoader.HTML_TEMPLATE_STRINGS_CONSTANT_TOKEN)) {
-                sb.append(StringUtils.join(strings, (",")));
+                appendReportConstantValues(strings, sb);
             } else if (line.equals(ResourceLoader.HTML_TEMPLATE_EXEC_ENV_TOKEN)) {
                 StringBuilder envInfoSb = new StringBuilder();
                 envInfoSb.append("{");
@@ -86,7 +94,7 @@ public class ReportWriterUtil {
                 sb.append("\n");
             }
         }
-        return sb;
+        return sb.toString();
     }
 
     public static String getOs() {
@@ -273,17 +281,13 @@ public class ReportWriterUtil {
 
     public static File writeTSCollectionHTMLReport(String reportTitle, String tsReportsJson, File destDir)
             throws IOException, URISyntaxException {
-        StringBuilder htmlSb = new StringBuilder();
-        readFileToStringBuilder(ResourceLoader.HTML_COLLECTION_INDEX_TEMPLATE, htmlSb);
-        String template = htmlSb.toString();
+        String template = readFileToStringBuilder(ResourceLoader.HTML_COLLECTION_INDEX_TEMPLATE);
         template = StringUtils.replace(template, "REPORT_TITLE", reportTitle);
         template = StringUtils.replace(template, "TEST_SUITE_REPORT_LIST", tsReportsJson);
         File indexFile = new File(destDir, "index.html");
         FileUtils.writeStringToFile(indexFile, template, StringConstants.DF_CHARSET);
 
-        htmlSb = new StringBuilder();
-        readFileToStringBuilder(ResourceLoader.HTML_COLLECTION_FRAME_TEMPLATE, htmlSb);
-        template = htmlSb.toString();
+        template = readFileToStringBuilder(ResourceLoader.HTML_COLLECTION_FRAME_TEMPLATE);
         template = StringUtils.replace(template, "REPORT_TITLE", reportTitle);
         template = StringUtils.replace(template, "TEST_SUITE_REPORT_LIST", tsReportsJson);
         FileUtils.writeStringToFile(new File(destDir, "index-frame-view.html"), template, StringConstants.DF_CHARSET);
@@ -292,38 +296,34 @@ public class ReportWriterUtil {
 
     public static void writeHtmlReport(TestSuiteLogRecord suiteLogEntity, File logFolder)
             throws IOException, URISyntaxException {
-        StringBuilder htmlSb = prepareHtmlContent(suiteLogEntity);
-
-        // Write main HTML Report
-        FileUtils.writeStringToFile(new File(logFolder, logFolder.getName() + ".html"), htmlSb.toString(),
-                StringConstants.DF_CHARSET);
+        File destFile = new File(logFolder, logFolder.getName() + ".html");
+        prepareHtmlContent(suiteLogEntity, destFile);
     }
 
-    private static StringBuilder prepareHtmlContent(TestSuiteLogRecord suiteLogEntity)
+    private static void prepareHtmlContent(TestSuiteLogRecord suiteLogEntity, File destFile)
             throws IOException, URISyntaxException {
         List<String> strings = new ArrayList<String>();
 
         JsSuiteModel jsSuiteModel = new JsSuiteModel(suiteLogEntity, strings);
         StringBuilder sbModel = jsSuiteModel.toArrayString();
 
-        StringBuilder htmlSb = new StringBuilder();
-        readFileToStringBuilder(ResourceLoader.HTML_TEMPLATE_FILE, htmlSb);
-        htmlSb.append(generateVars(strings, suiteLogEntity, sbModel));
-        readFileToStringBuilder(ResourceLoader.HTML_TEMPLATE_CONTENT, htmlSb);
-        return htmlSb;
+        FileUtils.writeStringToFile(destFile,
+                readFileToStringBuilder(ResourceLoader.HTML_TEMPLATE_FILE), StringConstants.DF_CHARSET);
+        FileUtils.writeStringToFile(destFile,
+                generateVars(strings, suiteLogEntity, sbModel), StringConstants.DF_CHARSET, true);
+        FileUtils.writeStringToFile(destFile,
+                readFileToStringBuilder(ResourceLoader.HTML_TEMPLATE_CONTENT), StringConstants.DF_CHARSET, true);
     }
 
     public static void writeHtmlReportAppendHashCodeToName(TestSuiteLogRecord suiteLogEntity, File logFolder,
             int reportDirLocationHashCode) throws IOException, URISyntaxException {
-        StringBuilder htmlSb = prepareHtmlContent(suiteLogEntity);
-
-        FileUtils.writeStringToFile(new File(logFolder, logFolder.getName() + reportDirLocationHashCode + ".html"),
-                htmlSb.toString(), StringConstants.DF_CHARSET);
+        File destFile = new File(logFolder, logFolder.getName() + reportDirLocationHashCode + ".html");
+        prepareHtmlContent(suiteLogEntity, destFile);
     }
 
     public static void writeExecutionUUIDToFile(String UUID, File logFolder) throws IOException, URISyntaxException {
         FileUtils.writeStringToFile(new File(logFolder, "execution.uuid"),
-                UUID, StringConstants.DF_CHARSET);
+        		UUID, StringConstants.DF_CHARSET);
     }
 
     public static void writeCSVReport(TestSuiteLogRecord suiteLogEntity, File folder) throws IOException {
@@ -346,42 +346,29 @@ public class ReportWriterUtil {
         List<String> simpleStrings = new LinkedList<String>();
         JsSuiteModel simpleJsSuiteModel = new JsSuiteModel(suiteLogEntity, simpleStrings);
         StringBuilder simpleSbModel = simpleJsSuiteModel.toArrayString();
-        StringBuilder simpleHtmlSb = new StringBuilder();
-        readFileToStringBuilder(ResourceLoader.HTML_TEMPLATE_FILE, simpleHtmlSb);
-        simpleHtmlSb.append(generateVars(simpleStrings, suiteLogEntity, simpleSbModel));
-        readFileToStringBuilder(ResourceLoader.HTML_TEMPLATE_CONTENT, simpleHtmlSb);
-        FileUtils.writeStringToFile(new File(logFolder, "Report.html"), simpleHtmlSb.toString(),
+        
+        File destSimpleFile = new File(logFolder, "Report.html");
+        FileUtils.writeStringToFile(destSimpleFile, readFileToStringBuilder(ResourceLoader.HTML_TEMPLATE_FILE),
                 StringConstants.DF_CHARSET);
+        FileUtils.writeStringToFile(destSimpleFile, generateVars(simpleStrings, suiteLogEntity, simpleSbModel),
+                StringConstants.DF_CHARSET, true);
+        FileUtils.writeStringToFile(destSimpleFile, readFileToStringBuilder(ResourceLoader.HTML_TEMPLATE_CONTENT),
+                StringConstants.DF_CHARSET, true);
     }
 
     public static void writeLogRecordToHTMLFile(TestSuiteLogRecord suiteLogEntity, File destFile,
             List<ILogRecord> filteredTestCases) throws IOException, URISyntaxException {
 
         List<String> strings = new LinkedList<String>();
-
-        JsSuiteModel jsSuiteModel = new JsSuiteModel(suiteLogEntity, strings);
+        JsSuiteModel jsSuiteModel = new JsSuiteModel(suiteLogEntity, strings, filteredTestCases);
         StringBuilder sbModel = jsSuiteModel.toArrayString();
 
-        StringBuilder htmlSb = new StringBuilder();
-        readFileToStringBuilder(ResourceLoader.HTML_TEMPLATE_FILE, htmlSb);
-        htmlSb.append(generateVars(strings, suiteLogEntity, sbModel));
-        readFileToStringBuilder(ResourceLoader.HTML_TEMPLATE_CONTENT, htmlSb);
-
-        // Remove Info Logs
-//        List<ILogRecord> infoLogs = new ArrayList<ILogRecord>();
-//        collectInfoLines(suiteLogEntity, infoLogs);
-//        for (ILogRecord infoLog : infoLogs) {
-//            infoLog.getParentLogRecord().removeChildRecord(infoLog);
-//        }
-        
-        strings = new LinkedList<String>();
-        jsSuiteModel = new JsSuiteModel(suiteLogEntity, strings, filteredTestCases);
-        sbModel = jsSuiteModel.toArrayString();
-        htmlSb = new StringBuilder();
-        readFileToStringBuilder(ResourceLoader.HTML_TEMPLATE_FILE, htmlSb);
-        htmlSb.append(generateVars(strings, suiteLogEntity, sbModel));
-        readFileToStringBuilder(ResourceLoader.HTML_TEMPLATE_CONTENT, htmlSb);
-        FileUtils.writeStringToFile(destFile, htmlSb.toString(), StringConstants.DF_CHARSET);
+        FileUtils.writeStringToFile(destFile, readFileToStringBuilder(ResourceLoader.HTML_TEMPLATE_FILE),
+                StringConstants.DF_CHARSET);
+        FileUtils.writeStringToFile(destFile, generateVars(strings, suiteLogEntity, sbModel),
+                StringConstants.DF_CHARSET, true);
+        FileUtils.writeStringToFile(destFile, readFileToStringBuilder(ResourceLoader.HTML_TEMPLATE_CONTENT),
+                StringConstants.DF_CHARSET, true);
     }
 
     public static List<XmlLogRecord> getAllLogRecords(String logFolder)
@@ -399,8 +386,9 @@ public class ReportWriterUtil {
         return generate(logFolder, new NullProgressMonitor());
     }
 
-    private static void readFileToStringBuilder(String fileName, StringBuilder sb)
+    private static String readFileToStringBuilder(String fileName)
             throws IOException, URISyntaxException {
+    	StringBuilder sb = new StringBuilder();
         String path = ResourceLoader.class.getProtectionDomain().getCodeSource().getLocation().getFile();
         path = URLDecoder.decode(path, "utf-8");
         File jarFile = new File(path);
@@ -427,5 +415,6 @@ public class ReportWriterUtil {
             InputStream is = (InputStream) ResourceLoader.class.getResource(fileName).getContent();
             sb.append(IOUtils.toString(is, "UTF-8"));
         }
+        return sb.toString();
     }
 }


### PR DESCRIPTION
## Progress

- [x] Resolve Java Heap space when exporting HTML for big Test Suite
_Note: This is a temporary solution, if we need to optimize more efficiently, we must re-code the **Write HTML Report** function_

## Solution
- Optimize code to free up more Heap spaces
- Expand Xms up to 4096 MB

## Checklist
- [x] Check base branch.
- [x] Write down ticket description on JIRA.
- [x] Verify all code changes are formatted.
- [ ] Review SonarCloud code quality report.