### PR TITLE
[STUDIO-6655] Split image as asset in report folder instead of embedding directly in HTML test suite report

### DIFF
--- a/Include/scripts/groovy/com/kms/katalon/core/reporting/basic/reporting/JsStepModel.java
+++ b/Include/scripts/groovy/com/kms/katalon/core/reporting/basic/reporting/JsStepModel.java
@@ -179,15 +179,10 @@ public class JsStepModel extends JsModel {
                     if (attachmentFile.exists()) {
                         try {
                             BundleSettingStore bundleSettingStore = new BundleSettingStore(RunConfiguration.getProjectDir(),
-                            		"com.katalon.plugin.report", true);
+                                    "com.katalon.plugin.report", true);
                             boolean useBase64 = !bundleSettingStore.getBoolean("useHTMLImageReferences", false);
-
-                            String linkValue;
-                            if (useBase64) {
-                            	linkValue = "data:image/png;base64," + encodeFileContent(attachmentFile);
-                            } else {
-                                linkValue = messageLog.getAttachment();
-                            }
+                            String linkValue = useBase64 ? "data:image/png;base64," + encodeFileContent(attachmentFile) :
+                                    messageLog.getAttachment();
                             jsLogRecModel.props.add(new JsModelProperty("link", linkValue, listStrings));
                         } catch (Exception e) {
                             // TODO: Need some way to log errors here

--- a/Include/scripts/groovy/com/kms/katalon/core/reporting/basic/reporting/JsStepModel.java
+++ b/Include/scripts/groovy/com/kms/katalon/core/reporting/basic/reporting/JsStepModel.java
@@ -18,6 +18,8 @@ import com.kms.katalon.core.logging.model.TestCaseLogRecord;
 import com.kms.katalon.core.logging.model.TestStatus.TestStatusValue;
 import com.kms.katalon.core.logging.model.TestStepLogRecord;
 import com.kms.katalon.core.logging.model.TestSuiteLogRecord;
+import com.kms.katalon.core.setting.BundleSettingStore;
+import com.kms.katalon.core.configuration.RunConfiguration;
 
 public class JsStepModel extends JsModel {
 
@@ -173,14 +175,26 @@ public class JsStepModel extends JsModel {
                             attachmentFile = new File(logFolder + File.separator + messageLog.getAttachment());
                         }
                     }
+                    
                     if (attachmentFile.exists()) {
                         try {
-                            jsLogRecModel.props.add(new JsModelProperty("link",
-                                    "data:image/png;base64," + encodeFileContent(attachmentFile), listStrings));
+                            String projectDir = RunConfiguration.getProjectDir();
+                            BundleSettingStore bundleSettingStore = new BundleSettingStore(projectDir, "com.katalon.plugin.report", true);
+                            boolean useBase64 = !bundleSettingStore.getBoolean("generateHTMLReferenceImages", false);
+
+                            String linkValue;
+                            if (useBase64) {
+                            	linkValue = "data:image/png;base64," + encodeFileContent(attachmentFile);
+                            } else if (attachmentFile.getPath().startsWith("/var/folders/")) {
+                                linkValue = attachmentFile.getName();
+                            } else {
+                                linkValue = attachmentFile.getPath();
+                            }
+                            jsLogRecModel.props.add(new JsModelProperty("link", linkValue, listStrings));
                         } catch (Exception e) {
                             // TODO: Need some way to log errors here
                         }
-                    }
+                    }          
                 }
                 logRecords.add(jsLogRecModel);
             }

--- a/Include/scripts/groovy/com/kms/katalon/core/reporting/basic/reporting/JsStepModel.java
+++ b/Include/scripts/groovy/com/kms/katalon/core/reporting/basic/reporting/JsStepModel.java
@@ -178,21 +178,21 @@ public class JsStepModel extends JsModel {
                     
                     if (attachmentFile.exists()) {
                         try {
-                            String projectDir = RunConfiguration.getProjectDir();
-                            BundleSettingStore bundleSettingStore = new BundleSettingStore(projectDir, "com.katalon.plugin.report", true);
+                            BundleSettingStore bundleSettingStore = new BundleSettingStore(RunConfiguration.getProjectDir(),
+                            		"com.katalon.plugin.report", true);
                             boolean useBase64 = !bundleSettingStore.getBoolean("useHTMLImageReferences", false);
 
                             String linkValue;
                             if (useBase64) {
                             	linkValue = "data:image/png;base64," + encodeFileContent(attachmentFile);
                             } else {
-                                linkValue = ((MessageLogRecord) logRecord).getAttachment();
+                                linkValue = messageLog.getAttachment();
                             }
                             jsLogRecModel.props.add(new JsModelProperty("link", linkValue, listStrings));
                         } catch (Exception e) {
                             // TODO: Need some way to log errors here
                         }
-                    }          
+                    }
                 }
                 logRecords.add(jsLogRecModel);
             }

--- a/Include/scripts/groovy/com/kms/katalon/core/reporting/basic/reporting/JsStepModel.java
+++ b/Include/scripts/groovy/com/kms/katalon/core/reporting/basic/reporting/JsStepModel.java
@@ -180,7 +180,7 @@ public class JsStepModel extends JsModel {
                         try {
                             String projectDir = RunConfiguration.getProjectDir();
                             BundleSettingStore bundleSettingStore = new BundleSettingStore(projectDir, "com.katalon.plugin.report", true);
-                            boolean useBase64 = !bundleSettingStore.getBoolean("generateHTMLReferenceImages", false);
+                            boolean useBase64 = !bundleSettingStore.getBoolean("useHTMLImageReferences", false);
 
                             String linkValue;
                             if (useBase64) {

--- a/Include/scripts/groovy/com/kms/katalon/core/reporting/basic/reporting/JsStepModel.java
+++ b/Include/scripts/groovy/com/kms/katalon/core/reporting/basic/reporting/JsStepModel.java
@@ -185,10 +185,8 @@ public class JsStepModel extends JsModel {
                             String linkValue;
                             if (useBase64) {
                             	linkValue = "data:image/png;base64," + encodeFileContent(attachmentFile);
-                            } else if (attachmentFile.getPath().startsWith("/var/folders/")) {
-                                linkValue = attachmentFile.getName();
                             } else {
-                                linkValue = attachmentFile.getPath();
+                                linkValue = ((MessageLogRecord) logRecord).getAttachment();
                             }
                             jsLogRecModel.props.add(new JsModelProperty("link", linkValue, listStrings));
                         } catch (Exception e) {

--- a/Keywords/katalon-plugin.json
+++ b/Keywords/katalon-plugin.json
@@ -31,6 +31,18 @@
 					"type": "checkbox",
 					"label": "PDF",
 					"defaultValue": "false"
+				},
+				{
+					"key": "lblHTMLFileStructure",
+					"type": "label",
+					"label": "HTML report file structure:"
+				},
+				{
+					"key": "generateHTMLReferenceImages",
+					"type": "checkboxAndHelpLink",
+					"label": "Attach reference images using linked screenshots (not embedded) to reduce report file size",
+					"link": "https://docs.katalon.com/katalon-studio/test-reports/view-test-reports/view-test-suite-and-test-suite-collection-reports-in-katalon-studio#automatically-generate-reports",
+					"defaultValue": "false"
 				}
 			]
 		}

--- a/Keywords/katalon-plugin.json
+++ b/Keywords/katalon-plugin.json
@@ -33,6 +33,11 @@
 					"defaultValue": "false"
 				},
 				{
+					"key": "",
+					"type": "label",
+					"label": ""
+				},
+				{
 					"key": "lblHTMLFileStructure",
 					"type": "label",
 					"label": "HTML report file structure:"

--- a/Keywords/katalon-plugin.json
+++ b/Keywords/katalon-plugin.json
@@ -38,8 +38,8 @@
 					"label": "HTML report file structure:"
 				},
 				{
-					"key": "generateHTMLReferenceImages",
-					"type": "checkboxAndHelpLink",
+					"key": "useHTMLImageReferences",
+					"type": "checkbox",
 					"label": "Attach reference images using linked screenshots (not embedded) to reduce report file size",
 					"link": "https://docs.katalon.com/katalon-studio/test-reports/view-test-reports/view-test-suite-and-test-suite-collection-reports-in-katalon-studio#automatically-generate-reports",
 					"defaultValue": "false"


### PR DESCRIPTION
### Description

- Add a checkbox for this option in Project Settings > Report
- Split image out instead of embedding directly in HTML test suite report

<img width="947" alt="Screenshot 2024-12-16 at 14 09 23" src="https://github.com/user-attachments/assets/5e38f466-619c-4298-8dfd-7515416ff273" />
<img width="579" alt="Screenshot 2024-12-16 at 12 50 00" src="https://github.com/user-attachments/assets/69d3a5b2-a3cf-447e-9383-b58d7d8e9277" />

![Screenshot 2024-12-16 at 14 17 52](https://github.com/user-attachments/assets/67774cce-5d05-44d6-a9c5-07f66476c609)
![Screenshot 2024-12-16 at 14 18 21](https://github.com/user-attachments/assets/1ae3c1a7-9927-4386-95e2-5b2643b7f738)


### References

[STUDIO-6655](https://katalon.atlassian.net/browse/STUDIO-6655)

### Checklist
 - [x] Check base branch
 - [x] All requirements are read and clear
 - [x] Tested by Dev field were input
 - [x] Verify all code changes are formatted
 - [ ] Review SonarCloud code quality report



[STUDIO-6655]: https://katalon.atlassian.net/browse/STUDIO-6655?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
